### PR TITLE
移除AntSports中的UserIdMap.setCurrentUid操作

### DIFF
--- a/app/src/main/java/tkaxv7s/xposed/sesame/model/task/antSports/AntSports.java
+++ b/app/src/main/java/tkaxv7s/xposed/sesame/model/task/antSports/AntSports.java
@@ -594,7 +594,7 @@ public class AntSports extends ModelTask {
                 int minGoStepCount = path.getInt("minGoStepCount");
                 if (jo.has("userPath")) {
                     JSONObject userPath = jo.getJSONObject("userPath");
-                    UserIdMap.setCurrentUid(userPath.getString("userId"));
+                    // UserIdMap.setCurrentUid(userPath.getString("userId"));
                     String userPathRecordStatus = userPath.getString("userPathRecordStatus");
                     if ("COMPLETED".equals(userPathRecordStatus)) {
                         pathMapHomepage(pathId);


### PR DESCRIPTION
子模块应该不需要进行此操作，在软件启动以及LauncherActivity显示时已进行UserIdMap.setCurrentUid操作