### PR TITLE
切换用户时复制配置文件

### DIFF
--- a/app/src/main/java/tkaxv7s/xposed/sesame/data/ConfigV2.java
+++ b/app/src/main/java/tkaxv7s/xposed/sesame/data/ConfigV2.java
@@ -134,13 +134,14 @@ public class ConfigV2 {
         }
         String json = JsonUtil.toJsonString(INSTANCE);
         Log.system(TAG, "保存 config_v2.json: " + json);
-        return FileUtil.write2File(json, FileUtil.getConfigV2File());
+        return FileUtil.setConfigV2File(json);
     }
 
     public static synchronized ConfigV2 load() {
         Log.i(TAG, "开始加载配置");
         Model.initAllModel();
         try {
+            Log.i(TAG, "currentUid： "+ UserIdMap.getCurrentUid());
             File configV2File = FileUtil.getConfigV2File(UserIdMap.getCurrentUid());
             if (configV2File.exists()) {
                 String json = FileUtil.readFromFile(configV2File);

--- a/app/src/main/java/tkaxv7s/xposed/sesame/util/UserIdMap.java
+++ b/app/src/main/java/tkaxv7s/xposed/sesame/util/UserIdMap.java
@@ -25,6 +25,7 @@ public class UserIdMap {
     public static void setCurrentUid(String uid) {
         if (currentUid == null || !currentUid.equals(uid)) {
             currentUid = uid;
+            FileUtil.setUid(uid);
             FriendManager.fillUser(ApplicationHook.getClassLoader());
         }
     }


### PR DESCRIPTION
切换用户时，将config目录下对应账号的配置文件读取写入到config_v2.json中。

问题：
1、启动支付宝app时，因为ConfigV2.load()先于setCurrentUid()执行，传入到getConfigV2File()的uid为null，并未获取对应的账号配置文件(config/config_v2-uid.json)，而只是读取了config_v2.json文件。所以如果在取消了激活模块后，切换了支付宝账号，再次激活时，因只读取了config_v2.json，所以配置是并非是当前账号的。