### PR TITLE
修复抢好友大战未授权报错问题

### DIFF
--- a/app/src/main/java/tkaxv7s/xposed/sesame/model/task/antSports/AntSports.java
+++ b/app/src/main/java/tkaxv7s/xposed/sesame/model/task/antSports/AntSports.java
@@ -842,6 +842,12 @@ public class AntSports extends ModelTask {
             String clubHomeResponse = AntSportsRpcCall.queryClubHome();
             TimeUtil.sleep(500);
             JSONObject clubHomeJson = new JSONObject(clubHomeResponse);
+            // 判断 clubAuth 字段是否为 "ENABLE"
+            if (!clubHomeJson.optString("clubAuth").equals("ENABLE")) {
+                // 如果 clubAuth 不是 "ENABLE"，停止执行
+                Log.record("抢好友大战🧑‍🤝‍🧑未授权开启");
+                return;
+            }
             // 获取 coinBalance 的值
             JSONObject assetsInfo = clubHomeJson.getJSONObject("assetsInfo");
             int coinBalance = assetsInfo.getInt("coinBalance");


### PR DESCRIPTION
修复抢好友大战未授权报错问题并打印日志，授权需手动打开运动-抢好友大战开启，开启后才能正常执行